### PR TITLE
Add vars for disconnected deployments

### DIFF
--- a/aap-prometheus-grafana/aap-prometheus-grafana-role/defaults/main.yml
+++ b/aap-prometheus-grafana/aap-prometheus-grafana-role/defaults/main.yml
@@ -5,3 +5,5 @@ ansible_namespace: ansible-automation-platform
 monitor_value: metrics
 user_id: "1"
 username: "admin"
+prometheus_catalog_source: community-operators
+grafana_catalog_source: community-operators

--- a/aap-prometheus-grafana/aap-prometheus-grafana-role/templates/grafana-operator.yaml.j2
+++ b/aap-prometheus-grafana/aap-prometheus-grafana-role/templates/grafana-operator.yaml.j2
@@ -10,5 +10,5 @@ spec:
   channel: v4
   installPlanApproval: Automatic
   name: grafana-operator
-  source: community-operators
+  source: {{ grafana_catalog_source }}
   sourceNamespace: openshift-marketplace

--- a/aap-prometheus-grafana/aap-prometheus-grafana-role/templates/prometheus-operator.yaml.j2
+++ b/aap-prometheus-grafana/aap-prometheus-grafana-role/templates/prometheus-operator.yaml.j2
@@ -10,7 +10,7 @@ spec:
   channel: beta
   installPlanApproval: Automatic
   name: prometheus
-  source: community-operators
+  source: {{ prometheus_catalog_source }}
   sourceNamespace: openshift-marketplace
 ---
 apiVersion: operators.coreos.com/v1


### PR DESCRIPTION
Nice blog post, thanks.
https://www.ansible.com/blog/monitoring-red-hat-ansible-automation-platform-on-red-hat-openshift-the-easy-way 

I just parametrized the source field in the grafana / prometheus subscriptions to make it configurable via a variable and unlock your demo in OCP disconnected environments as well.

If no `*_catalog_source` extra var is provided, it just takes the `community-operators` as the default source name (same behavior as before, corresponding to connected OCP deployments).